### PR TITLE
Changed TRNAMT parser

### DIFF
--- a/perl/lib/Finance/OFX/Parse/Simple.pm
+++ b/perl/lib/Finance/OFX/Parse/Simple.pm
@@ -131,16 +131,16 @@ sub parse_scalar
 
 		if ($s =~ m/<TRNAMT>\s*([-+])?\s*        # positive-negative sign $1
 		    (?:(\d+)                             # whole numbers $2
-		     (?:\Q$decimal_separator\E(\d\d)?)?  # optionally followed by fractional number $3
+		     (?:\Q$decimal_separator\E(\d\d?)?)? # optionally followed by fractional number $3
 		     |                                   # or
-		     \Q$decimal_separator\E(\d\d))       # just the fractional part $4
+		     \Q$decimal_separator\E(\d\d?))      # just the fractional part $4
 		    /sx)
 		{
 		    my $posneg = $1 || "";
 		    my $whole  = $2 || 0;
 		    my $frac   = $3 || $4 || 0;
 
-		    $amount = sprintf("%.2f", ($whole + ($frac / 100)) * (($posneg eq '-') 
+		    $amount = sprintf("%.2f", ($whole + ("0.$frac" / 1)) * (($posneg eq '-') 
 									  ? -1 
 									  : 1));
 		}

--- a/perl/t/01-main.t
+++ b/perl/t/01-main.t
@@ -49,6 +49,13 @@ my $ofx_data = qq[<OFX>
 		  <FITID>+20080603000001
 		  <NAME>Transaction $$
 		  </STMTTRN>
+		  <STMTTRN>
+		  <TRNTYPE>OTHER
+		  <DTPOSTED>20080603000000[-5:EST]
+		  <TRNAMT>36.5
+		  <FITID>+20080603000001
+		  <NAME>Transaction $$
+		  </STMTTRN>
 		  </BANKTRANLIST>
 		  <LEDGERBAL>
 		  <BALAMT>1668.75
@@ -68,6 +75,9 @@ ok( (ref($parser->parse_scalar($ofx_data)->[0]) eq 'HASH'),
 
 ok( ($parser->parse_scalar($ofx_data)->[0]->{transactions}->[0]->{name} eq "Transaction $$"),
     "OFX data is parsed correctly");
+
+ok( ($parser->parse_scalar($ofx_data)->[0]->{transactions}->[1]->{amount} eq "36.50"),
+    "OFX partial decimal data is parsed correctly");
 
 {
     $ofx_data =~ s/(<TRNAMT>\d+)\./$1,/sg or die;


### PR DESCRIPTION
I encountered an OFX file that formatted numbers like 12.30 as 12.3

I changed the TRNAMT parse regex, etc. to also read that format.
Also added a test to verify it reads those correctly.
